### PR TITLE
fix: changed bg secondary for light mode

### DIFF
--- a/src/Provider/index.tsx
+++ b/src/Provider/index.tsx
@@ -54,7 +54,7 @@ export function Provider({
     inputField: "#757575",
     success: "#17A815",
     fail: "#EB0000",
-    backgroundSecondary: "#333333",
+    backgroundSecondary: "#CCCCCC",
     delete: "#F58080",
     secondaryDelete: "#F58080"
   };


### PR DESCRIPTION
This fixes the degraded message bg color for light mode, previously light mode and dark mode secondary color were the same


corresponds with: https://github.com/arconnectio/ArConnect/pull/397